### PR TITLE
broken parser with long responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ function isMark(code) {
 function ResponseParser() {
   this. currentCode = 0;
   this. buffer = [];
+  this. fragment = '';
 
   stream.Transform.call(this, {
     objectMode: true
@@ -22,7 +23,9 @@ function ResponseParser() {
 util.inherits(ResponseParser, stream.Transform);
 
 ResponseParser.prototype._transform = function(chunk, encoding, done) {
-  var data = chunk.toString();
+  var data = this.fragment + chunk.toString();
+  this.fragment = /[^\n]*$/.exec(data)[0];
+
   var lines = data.split(/\r?\n/).filter(function(l) {
     return !!l;
   });

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ util.inherits(ResponseParser, stream.Transform);
 ResponseParser.prototype._transform = function(chunk, encoding, done) {
   var data = this.fragment + chunk.toString();
   this.fragment = /[^\n]*$/.exec(data)[0];
+  data = data.slice(0, data.length - this.fragment.length);
 
   var lines = data.split(/\r?\n/).filter(function(l) {
     return !!l;


### PR DESCRIPTION
https://github.com/sergi/jsftp/issues/46 the chunks recieved by _transform are not necesarily split at line feeds. The part of the line after the last line feed needs preserving until the next data is recieved.
